### PR TITLE
Fix last update to display date of last Indaba fetch

### DIFF
--- a/api.js
+++ b/api.js
@@ -19,14 +19,15 @@ function api_call (endpoint, callback) {
   }
   if (should_get_from_cache) {
     var data = fs.readFileSync(cache_file);
-    callback(JSON.parse(data));
+    var date = new Date(stat.mtime);
+    callback(JSON.parse(data), date);
   } else {
 
     Indaba.getTrackerJSON().then( function (res) {
       if (should_update_cache) {
         fs.writeFileSync(cache_file, JSON.stringify(res));
       }
-      callback(res);
+      callback(res, new Date());
     });
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -296,20 +296,7 @@ router.get('/locale/:locale/embed', function (req, res) {
 });
 
 router.get('/', function (req, res) {
-  api.call('countries', function (countries) {
-    // If today is less than the 22nd of the month the data is from
-    // the last date of two months ago else it's from last date of one
-    // month ago
-    var last_update = new Date();
-    if (last_update.getDate() < 22) {
-      last_update = new Date(last_update.getFullYear(),
-                             last_update.getMonth()-1, 0);
-    }
-    else {
-      last_update = new Date(last_update.getFullYear(),
-                             last_update.getMonth(), 0);
-    }
-
+  api.call('countries', function (countries, last_update) {
     //Override countries (e.g. discontinued countries)
     countries = _.map(countries, function(obj) {
       if (obj.country in country_override) {
@@ -332,20 +319,7 @@ router.get('/', function (req, res) {
 });
 
 router.get('/embed', function (req, res) {
-  api.call('countries', function (countries) {
-    // If today is less than the 22nd of the month the data is from
-    // the last date of two months ago else it's from last date of one
-    // month ago
-    var last_update = new Date();
-    if (last_update.getDate() < 22) {
-      last_update = new Date(last_update.getFullYear(),
-                             last_update.getMonth()-1, 0);
-    }
-    else {
-      last_update = new Date(last_update.getFullYear(),
-                             last_update.getMonth(), 0);
-    }
-
+  api.call('countries', function (countries, last_update) {
     //Override countries (e.g. discontinued countries)
     countries = _.map(countries, function(obj) {
       if (obj.country in country_override) {


### PR DESCRIPTION
Fixes okfn/open-budget-survey#70

The last update date was following the old Aquarium API intervals.

Now the last update displayed is the last time when the cache is updated from Indaba. Currently we don't have any mechanism to see when the data was last updated via the API. One other possible option to have more recent API change is to compare all documents dates to find the newest.